### PR TITLE
fix meshtastic library version mismatch with setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyside6
 PyGithub
 esptool
-meshtastic>=1.2.80
+meshtastic>=1.2.85
 qt-material
 psutil
 adafruit-nrfutil


### PR DESCRIPTION
setup.py was update with out mirroring the changes to requirements.txt. This pull request fixes that.