### PR TITLE
Update main form layout

### DIFF
--- a/meshtastic_flasher/form.py
+++ b/meshtastic_flasher/form.py
@@ -33,7 +33,9 @@ import meshtastic_flasher.util
 MESHTASTIC_LOGO_FILENAME = "logo.png"
 COG_FILENAME = "cog.svg"
 HELP_FILENAME = "help.svg"
+INFO_FILENAME = "info.svg"
 BUTTON_ICON_SIZE = QtCore.QSize(24, 24)
+BUTTON_ICON_SIZE_SMALL = QtCore.QSize(20, 20)
 
 # windows does not like this one
 if platform.system() == "Linux":
@@ -90,10 +92,20 @@ class Form(QDialog):
         self.help_button = QPushButton()
         help_icon = QIcon(meshtastic_flasher.util.get_path(HELP_FILENAME))
         self.help_button.setIcon(help_icon)
-        self.help_button.setIconSize(BUTTON_ICON_SIZE)
-        self.help_button.setFixedWidth(42)
+        self.help_button.setIconSize(BUTTON_ICON_SIZE_SMALL)
+        self.help_button.setFixedSize(BUTTON_ICON_SIZE_SMALL)
         self.help_button.setCursor(QCursor(QtCore.Qt.PointingHandCursor))
-        self.help_button.setToolTip("Click for help.")
+        self.help_button.setStyleSheet("border:none")
+        self.help_button.setToolTip("Click for help | Press H for hotkeys.")
+
+        self.about_button = QPushButton()
+        help_icon = QIcon(meshtastic_flasher.util.get_path(INFO_FILENAME))
+        self.about_button.setIcon(help_icon)
+        self.about_button.setIconSize(BUTTON_ICON_SIZE_SMALL)
+        self.about_button.setFixedSize(BUTTON_ICON_SIZE_SMALL)
+        self.about_button.setCursor(QCursor(QtCore.Qt.PointingHandCursor))
+        self.about_button.setStyleSheet("border:none")
+        self.about_button.setToolTip("Click for info about the project.")
 
         self.select_port = QComboBox()
         self.select_port.setToolTip("Click GET VERSIONS and DETECT DEVICE before you can select the port.")
@@ -116,14 +128,12 @@ class Form(QDialog):
         self.progress.hide()
 
         self.logo = QLabel(self)
-        self.logo.setToolTip("This is the Meshtastic logo. Click to visit Meshtastic.org.")
         pixmap = QPixmap(meshtastic_flasher.util.get_path(MESHTASTIC_LOGO_FILENAME))
         self.logo.setPixmap(pixmap.scaled(256, 256, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation))
         self.logo.setAlignment(QtCore.Qt.AlignCenter)
         style_for_logo = (f"background-color: {MESHTASTIC_COLOR_GREEN}; border-color: "
                           f"{MESHTASTIC_COLOR_GREEN}; border-radius: 0px; color: {MESHTASTIC_COLOR_DARK};")
         self.logo.setStyleSheet(style_for_logo)
-        self.logo.setCursor(QCursor(QtCore.Qt.PointingHandCursor))
 
         # labels for over the drop downs/combo boxes
         self.label_version = QLabel(self)
@@ -154,16 +164,22 @@ class Form(QDialog):
         # Create layout and add widgets
         main_layout = QVBoxLayout()
         main_layout.setContentsMargins(0, 0, 0, 0)
-        if self.logo:
-            main_layout.addWidget(self.logo)
 
-        main_layout.addStretch(1)
+        info_layout = QHBoxLayout()
+        info_layout.addWidget(self.about_button, alignment=QtCore.Qt.AlignRight)
+        info_layout.addWidget(self.help_button)
+        info_layout.setContentsMargins(0, 5, 10, 0)
+
+        logo_layout = QVBoxLayout()
+        if self.logo:
+            logo_layout.addWidget(self.logo)
+
+        logo_layout.addStretch(1)
 
         detect_layout = QHBoxLayout()
         detect_layout.addStretch(1)
         detect_layout.addWidget(self.get_versions_button)
         detect_layout.addWidget(self.select_detect)
-        detect_layout.addWidget(self.help_button)
         detect_layout.addWidget(self.settings_cog)
         detect_layout.setContentsMargins(0, 0, 0, 0)
         detect_layout.addStretch(1)
@@ -193,6 +209,8 @@ class Form(QDialog):
         button_layout.addStretch(1)
 
         # Set layout
+        main_layout.addLayout(info_layout)
+        main_layout.addLayout(logo_layout)
         main_layout.addLayout(detect_layout)
         main_layout.addLayout(label_layout)
         main_layout.addLayout(button_layout)
@@ -209,9 +227,9 @@ class Form(QDialog):
         #self.settings_cog.show()
 
         # Add button signals to slots
-        self.logo.mousePressEvent = self.logo_clicked
         self.get_versions_button.clicked.connect(self.get_versions)
-        self.help_button.clicked.connect(self.hotkeys)
+        self.help_button.clicked.connect(self.help_message)
+        self.about_button.clicked.connect(self.about_message)
         self.label_version.mousePressEvent = self.label_version_clicked
         self.label_device.mousePressEvent = self.label_device_clicked
         self.select_detect.clicked.connect(self.detect)
@@ -241,8 +259,8 @@ class Form(QDialog):
             print("Q was pressed... so quitting")
             QApplication.quit()
         elif event.key() == QtCore.Qt.Key_T:
-            print("T was pressed... so showing tips")
-            self.tips()
+            print("T was pressed... so showing help message")
+            self.help_message()
         elif event.key() == QtCore.Qt.Key_S:
             print("S was pressed... showing settings form")
             self.run_settings(None)
@@ -349,14 +367,13 @@ class Form(QDialog):
                     self.select_device.addItem(device)
 
 
-
-    def tips(self):
-        """Show tips"""
-        print("tips")
+    def help_message(self):
+        """Show help message"""
+        print("help_message")
         msg_box = QMessageBox()
+        msg_box.setWindowTitle("Help")
         msg_box.setTextFormat(QtCore.Qt.RichText)  # this is what makes the links clickable
-        msg_box.setText("<u>Tips:</u><br>"
-                        "If having issues flashing the device, be sure there is only one <a href='https://meshtastic.org/docs/hardware' style='color:#67EA94'>supported device</a> connected "
+        msg_box.setText("If having issues flashing the device, be sure there is only one <a href='https://meshtastic.org/docs/hardware' style='color:#67EA94'>supported device</a> connected "
                         "and no other applications are using that communications port.<br><br>"
                         "If still having problems, unplug the device, then re-plugin the device.<br><br>"
                         "If still having problems, consider using a different usb port, perhaps an external usb hub or even a different computer and/or different operating system.<br><br>"
@@ -371,6 +388,17 @@ class Form(QDialog):
                         "If you get a 'Critical Fault #6' on a T-Beam, it probably means you need to use "
                         "v1.1 or v2.1.1.6 firmware.<br><br>"
                         "Join the <a href='https://discord.com/invite/UQJ5QuM7vq' style='color:#67EA94'>Meshtastic Discord group</a> and post questions in #help channel.")
+        msg_box.setStandardButtons(QMessageBox.Ok)
+        msg_box.exec()
+
+    def about_message(self):
+        """Show info about_message"""
+        print("about_message")
+        msg_box = QMessageBox()
+        msg_box.setWindowTitle("About Meshtastic Flasher")
+        msg_box.setTextFormat(QtCore.Qt.RichText)
+        msg_box.setText("Meshtastic Flasher is part of the <a href='https://meshtastic.org' style='color:#67EA94'>Meshtastic</a> ecosystem. "
+                        "It is a cross platform, easy to use GUI for installing Meshtastic firmware.")
         msg_box.setStandardButtons(QMessageBox.Ok)
         msg_box.exec()
 
@@ -873,13 +901,6 @@ class Form(QDialog):
         self.progress.setValue(100)
         QApplication.processEvents()
         print("end of detect")
-
-
-    # pylint: disable=unused-argument
-    def logo_clicked(self, event):
-        """The logo was clicked."""
-        print("The logo was clicked")
-        webbrowser.open('https://meshtastic.org')
 
 
     def flash_nrf52(self):

--- a/meshtastic_flasher/info.svg
+++ b/meshtastic_flasher/info.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="#67EA94">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+</svg>

--- a/meshtastic_flasher/tests/test_form.py
+++ b/meshtastic_flasher/tests/test_form.py
@@ -45,22 +45,6 @@ def test_buttons_and_combo_boxes(faked_versions, fake_check_newer, qtbot):
     fake_check_newer.assert_called()
 
 
-@patch('meshtastic_flasher.util.check_if_newer_version')
-@patch('meshtastic_flasher.form.Form.get_versions_from_disk')
-@patch('webbrowser.open')
-def test_logo_clicked(fake_open, fake_versions, fake_check_newer, qtbot, capsys):
-    """Test logo clicked in Form"""
-    widget = Form()
-    qtbot.addWidget(widget)
-    qtbot.mouseClick(widget.logo, qt_api.QtCore.Qt.MouseButton.LeftButton)
-    out, err = capsys.readouterr()
-    assert re.search(r'The logo was clicked', out, re.MULTILINE)
-    assert err == ''
-    fake_open.assert_called()
-    fake_versions.assert_called()
-    fake_check_newer.assert_called()
-
-
 #@patch('meshtastic_flasher.util.check_if_newer_version')
 #@patch('meshtastic_flasher.form.Form.get_versions_from_disk')
 #@patch('esptool.main')

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     packages=["meshtastic_flasher"],
     include_package_data=True,
     package_data={
-        '': ['logo.png', 'help.svg', 'cog.svg', 'meshtastic_theme.xml', 'fields.json'],
+        '': ['logo.png', 'help.svg', 'info.svg', 'cog.svg', 'meshtastic_theme.xml', 'fields.json'],
     },
     install_requires=["pyside6", "PyGithub", "esptool", "meshtastic>=1.2.85", "qt-material",
                       "psutil", "adafruit-nrfutil", "pyserial", "geocoder"],


### PR DESCRIPTION
 - Move the 'tips' message to 'help' message
 - Remove the 'hotkeys' push button from the detect layout
 - Add a hint to hotkeys in 'help' push button tool tip
 - Add 'about' and 'help' push buttons to upper right corner of the form
 - Add the 'about' message content
 - Remove the clickable link from the center logo