### PR TITLE
Update form.py

### DIFF
--- a/meshtastic_flasher/form.py
+++ b/meshtastic_flasher/form.py
@@ -453,10 +453,8 @@ class Form(QDialog):
         # for item in items:
         #     self.select_firmware_version.addItem(item)
         if len(items) > 0:
-            self.select_firmware_version.addItem(items[0])
-        elif len(items) > 1:
-            self.select_firmware_version.addItem(items[0])
-            self.select_firmware_version.addItem(items[1])
+            for item in items:
+                self.select_firmware_version.addItem(item)
             
         self.select_firmware_version.setCurrentIndex(0)
 

--- a/meshtastic_flasher/form.py
+++ b/meshtastic_flasher/form.py
@@ -452,7 +452,9 @@ class Form(QDialog):
         self.select_firmware_version.clear()
         # for item in items:
         #     self.select_firmware_version.addItem(item)
-        if len(items) > 1:
+        if len(items) > 0:
+            self.select_firmware_version.addItem(items[0])
+        elif len(items) > 1:
             self.select_firmware_version.addItem(items[0])
             self.select_firmware_version.addItem(items[1])
             


### PR DESCRIPTION
Dirty quickfix for sort_firmware_versions for the cases when regexp in util.py Line 58 returns only one firmware tag. Before dropdown worked only for the first two tags and only if there are at least 2 tags.